### PR TITLE
Bugfix: cgroups configuration

### DIFF
--- a/reactive/storpool_common.py
+++ b/reactive/storpool_common.py
@@ -225,6 +225,16 @@ def install_package():
                     rdebug('- generating {dst}'.format(dst=dst))
                     txn.install('-o', 'root', '-g', 'root', '-m', '644', '--',
                                 tempf.name, dst)
+            elif fname == 'storpool_cgmove_cron':
+                if os.path.isfile(dst):
+                    rdebug('- removing stale file {dst}'.format(dst=dst))
+                    try:
+                        os.unlink(dst)
+                    except Exception as e:
+                        rdebug('COULD NOT remove {dst}: {e}'
+                               .format(dst=dst, e=e))
+                else:
+                    rdebug('- not installing stale {src}'.format(src=src))
             else:
                 mode = '{:o}'.format(os.stat(src).st_mode & 0o777)
                 rdebug('- installing {src} as {dst}'.format(src=src, dst=dst))

--- a/reactive/storpool_common.py
+++ b/reactive/storpool_common.py
@@ -4,6 +4,7 @@ A Juju charm layer that installs the base StorPool packages.
 from __future__ import print_function
 
 import os
+import re
 import subprocess
 import tempfile
 
@@ -101,6 +102,23 @@ def install_package():
     spstatus.npset('maintenance', 'updating the kernel module dependencies')
     subprocess.check_call(['depmod', '-a'])
 
+    rdebug('gathering swap usage information for the cgroup configuration')
+    re_number = re.compile('(?: 0 | [1-9][0-9]* )$', re.X)
+    total_swap = 0
+    with open('/proc/swaps', mode='r') as f:
+        for line in f.readlines():
+            fields = line.split()
+            if len(fields) < 4:
+                continue
+            total = fields[2]
+            used = fields[3]
+            if not (re_number.match(total) and re_number.match(used)):
+                continue
+            rdebug('- {}'.format(total))
+            total_swap += int(total)
+    total_swap = int(total_swap / 1024)
+    rdebug('- total: {} MB of swap'.format(total_swap))
+
     rdebug('gathering CPU information for the cgroup configuration')
     with open('/proc/cpuinfo', mode='r') as f:
         lns = f.readlines()
@@ -165,9 +183,12 @@ def install_package():
     mem_machine = mem_total - mem_reserved
     tdata.update({
         'mem_system': mem_system,
+        'memsw_system': mem_system + total_swap,
         'mem_user': mem_user,
+        'memsw_user': mem_user + total_swap,
         'mem_storpool': mem_storpool,
         'mem_machine': mem_machine,
+        'memsw_machine': mem_machine + total_swap,
     })
 
     rdebug('generating the cgroup configuration: {tdata}'.format(tdata=tdata))

--- a/reactive/storpool_common.py
+++ b/reactive/storpool_common.py
@@ -94,11 +94,11 @@ def install_package():
 
     spstatus.npset('maintenance', 'installing the StorPool common packages')
     (err, newly_installed) = sprepo.install_packages({
-        'storpool-cli': spver,
-        'storpool-common': spver,
-        'storpool-etcfiles': spver,
-        'kmod-storpool-' + os.uname().release: spver,
-        'python-storpool': spver,
+        'storpool-cli': '*',
+        'storpool-common': '*',
+        'storpool-etcfiles': '*',
+        'kmod-storpool-' + os.uname().release: '*',
+        'python-storpool': '*',
     })
     if err is not None:
         rdebug('oof, we could not install packages: {err}'.format(err=err))

--- a/templates/machine.slice.conf
+++ b/templates/machine.slice.conf
@@ -7,6 +7,6 @@ group machine.slice {
             memory.move_charge_at_immigrate="1";
             memory.use_hierarchy="1";
             memory.limit_in_bytes="{{ mem_machine }}M";
-            memory.memsw.limit_in_bytes="{{ mem_machine }}M";
+            memory.memsw.limit_in_bytes="{{ memsw_machine }}M";
     }
 }

--- a/templates/system.slice.conf
+++ b/templates/system.slice.conf
@@ -7,6 +7,6 @@ group system.slice {
             memory.move_charge_at_immigrate="1";
             memory.use_hierarchy="1";
             memory.limit_in_bytes="{{ mem_system }}M";
-            memory.memsw.limit_in_bytes="{{ mem_system }}M";
+            memory.memsw.limit_in_bytes="{{ memsw_system }}M";
     }
 }

--- a/templates/user.slice.conf
+++ b/templates/user.slice.conf
@@ -7,6 +7,6 @@ group user.slice {
             memory.move_charge_at_immigrate="1";
             memory.use_hierarchy="1";
             memory.limit_in_bytes="{{ mem_user }}M";
-            memory.memsw.limit_in_bytes="{{ mem_user }}M";
+            memory.memsw.limit_in_bytes="{{ memsw_user }}M";
     }
 }


### PR DESCRIPTION
Do not install the cgroups configuration at all when running in a container (e.g. the cinder-storpool charm).
Do not install (and remove) a stale configuration file.